### PR TITLE
Timberwolf/gimme multi hq

### DIFF
--- a/indicoio/utils/multi.py
+++ b/indicoio/utils/multi.py
@@ -11,8 +11,6 @@ AVAILABLE_APIS = {
     'image': IMAGE_APIS
 }
 
-# TODO: remove this line when sentiment_hq is released publicly
-AVAILABLE_APIS['text'].remove('sentiment_hq')
 
 def multi(data, datatype, apis, batch=False, **kwargs):
     """


### PR DESCRIPTION
When I tried using predict_text with sentiment_hq, I got an exception saying it wasn't one of the APIs that can be used with predict_text(also damn, very nice touch). I found out it's because it was specifically removed with a comment mentioning that it should be un-removed once sentiment_hq is public. Now it is so now we yay!