### PR TITLE
Python 2/3 support

### DIFF
--- a/indicoio/config.py
+++ b/indicoio/config.py
@@ -1,9 +1,10 @@
 import os
-from StringIO import StringIO
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
-import ConfigParser
-
-class Settings(ConfigParser.ConfigParser):
+class Settings(configparser.ConfigParser):
 
     def __init__(self, *args, **kwargs):
         """
@@ -11,12 +12,18 @@ class Settings(ConfigParser.ConfigParser):
         """
         self.files = kwargs.pop('files')
 
-        ConfigParser.ConfigParser.__init__(self, *args, **kwargs)
+        configparser.ConfigParser.__init__(self, *args, **kwargs)
 
         for fd in self.files:
             try:
-                self.readfp(fd)
+                self.read_file(fd)
             except AttributeError:
+                # python 2
+                try:
+                    self.readfp(fd)
+                except AttributeError:
+                    self.read(fd)
+            except configparser.MissingSectionHeaderError:
                 self.read(fd)
 
         self.auth_settings = self.get_section('auth')
@@ -24,11 +31,11 @@ class Settings(ConfigParser.ConfigParser):
 
     def get_section(self, section):
         """
-        Retrieve a ConfigParser section as a dictionary, default to {}
+        Retrieve a configparser section as a dictionary, default to {}
         """
         try:
             return dict(self.items(section))
-        except ConfigParser.NoSectionError:
+        except configparser.NoSectionError:
             return {}
 
     def cloud(self):

--- a/indicoio/images/faciallocalization.py
+++ b/indicoio/images/faciallocalization.py
@@ -1,5 +1,3 @@
-import requests
-
 from indicoio.utils.image import image_preprocess
 from indicoio.utils.api import api_handler
 

--- a/indicoio/images/features.py
+++ b/indicoio/images/features.py
@@ -1,5 +1,3 @@
-import requests
-
 from indicoio.utils.image import image_preprocess
 from indicoio.utils.api import api_handler
 

--- a/indicoio/images/fer.py
+++ b/indicoio/images/fer.py
@@ -1,8 +1,5 @@
-import requests
-
 from indicoio.utils.api import api_handler
 from indicoio.utils.image import image_preprocess
-import indicoio.config as config
 
 def fer(image, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/images/filtering.py
+++ b/indicoio/images/filtering.py
@@ -1,8 +1,5 @@
-import requests
-
 from indicoio.utils.api import api_handler
 from indicoio.utils.image import image_preprocess
-import indicoio.config as config
 
 def content_filtering(image, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/images/recognition.py
+++ b/indicoio/images/recognition.py
@@ -1,5 +1,3 @@
-import requests
-
 from indicoio.utils.image import image_preprocess
 from indicoio.utils.api import api_handler
 

--- a/indicoio/text/keywords.py
+++ b/indicoio/text/keywords.py
@@ -1,5 +1,4 @@
 from indicoio.utils.api import api_handler
-import indicoio.config as config
 
 def keywords(text, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/text/lang.py
+++ b/indicoio/text/lang.py
@@ -1,5 +1,4 @@
 from indicoio.utils.api import api_handler
-import indicoio.config as config
 
 def language(text, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/text/ner.py
+++ b/indicoio/text/ner.py
@@ -1,5 +1,4 @@
 from indicoio.utils.api import api_handler
-import indicoio.config as config
 
 def named_entities(text, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/text/tagging.py
+++ b/indicoio/text/tagging.py
@@ -1,5 +1,4 @@
 from indicoio.utils.api import api_handler
-import indicoio.config as config
 
 def text_tags(text, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/text/twitter_engagement.py
+++ b/indicoio/text/twitter_engagement.py
@@ -1,5 +1,4 @@
 from indicoio.utils.api import api_handler
-import indicoio.config as config
 
 def twitter_engagement(text, cloud=None, batch=False, api_key=None, version=None, **kwargs):
     """

--- a/indicoio/utils/__init__.py
+++ b/indicoio/utils/__init__.py
@@ -2,6 +2,7 @@
 Basic utility classes and functions
 """
 import inspect
+from six import string_types
 
 from indicoio.utils.errors import DataStructureException
 
@@ -34,8 +35,8 @@ class TypeCheck(object):
 
 
 def is_url(data, batch=False):
-    if batch and isinstance(data[0], basestring):
+    if batch and isinstance(data[0], string_types):
         return True
-    if not batch and isinstance(data, basestring):
+    if not batch and isinstance(data, string_types):
         return True
     return False

--- a/indicoio/utils/api.py
+++ b/indicoio/utils/api.py
@@ -4,7 +4,7 @@ Handles making requests to the IndicoApi Server
 
 import json, requests
 
-from indicoio.utils.errors import IndicoError, DataStructureException
+from indicoio.utils.errors import IndicoError
 from indicoio import JSON_HEADERS
 from indicoio import config
 
@@ -13,6 +13,10 @@ def api_handler(arg, cloud, api, url_params=None, **kwargs):
     Sends finalized request data to ML server and receives response.
     """
 
+    if type(arg) == bytes:
+        arg = arg.decode('utf-8')
+    if type(arg) == list:
+        arg = [a.decode('utf-8') if type(arg) == bytes else a for a in arg]
     data = {'data': arg}
     data.update(**kwargs)
     json_data = json.dumps(data)

--- a/indicoio/utils/image.py
+++ b/indicoio/utils/image.py
@@ -2,11 +2,12 @@
 Image Utils
 Handles preprocessing images before they are sent to the server
 """
-import os.path, base64, StringIO, re, warnings
+import os.path, base64, re, warnings
+from six import BytesIO, string_types, PY3
 
 from PIL import Image
 
-from indicoio.utils.errors import IndicoError, DataStructureException
+from indicoio.utils.errors import IndicoError
 
 B64_PATTERN = re.compile("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)")
 
@@ -18,7 +19,7 @@ def image_preprocess(image, size=None, min_axis=None, batch=False):
     if batch:
         return [image_preprocess(img, batch=False) for img in image]
 
-    if isinstance(image, basestring):
+    if isinstance(image, string_types):
         b64_str = re.sub('^data:image/.+;base64,', '', image)
         if os.path.isfile(image):
             # check type of element
@@ -45,12 +46,12 @@ def image_preprocess(image, size=None, min_axis=None, batch=False):
         out_image = resize_image(out_image, size, min_axis)
 
     # convert to base64
-    temp_output = StringIO.StringIO()
+    temp_output = BytesIO()
     out_image.save(temp_output, format='PNG')
     temp_output.seek(0)
     output_s = temp_output.read()
 
-    return base64.b64encode(output_s)
+    return base64.b64encode(output_s).decode('utf-8') if PY3 else base64.b64encode(output_s)
 
 
 def resize_image(image, size, min_axis):
@@ -87,6 +88,6 @@ def get_element_type(_list, dimens):
     elements in the inner list.
     """
     elem = _list
-    for _ in xrange(len(dimens)):
+    for _ in range(len(dimens)):
         elem = elem[0]
     return type(elem)

--- a/indicoio/utils/multi.py
+++ b/indicoio/utils/multi.py
@@ -5,7 +5,7 @@ from indicoio.utils.errors import IndicoError
 
 
 CLIENT_SERVER_MAP = dict((api, api.strip().replace("_", "").lower()) for api in API_NAMES)
-SERVER_CLIENT_MAP = dict((v, k) for k, v in CLIENT_SERVER_MAP.iteritems())
+SERVER_CLIENT_MAP = dict((v, k) for k, v in CLIENT_SERVER_MAP.items())
 AVAILABLE_APIS = {
     'text': TEXT_APIS,
     'image': IMAGE_APIS
@@ -13,7 +13,7 @@ AVAILABLE_APIS = {
 
 def invert_dictionary(d):
     return {
-        element: key for key, values in d.iteritems()
+        element: key for key, values in d.items()
         for element in values
     }
 
@@ -40,7 +40,7 @@ def intersections(data, apis = None, **kwargs):
             "At least 3 examples are required to use the intersections API"
         )
 
-    api_types = map(API_TYPES.get, apis)
+    api_types = list(map(API_TYPES.get, apis))
     if api_types[0] != api_types[1]:
         raise IndicoError(
             "Both `apis` must accept the same kind of input to use the intersections API"
@@ -95,7 +95,7 @@ def multi(data, datatype, apis, batch=False, **kwargs):
 def handle_response(result):
     # Parse out the results to a dicionary of api: result
     return dict((api, parsed_response(api, res))
-        for api, res in result.iteritems())
+        for api, res in result.items())
 
 
 def analyze_text(input_text, apis=TEXT_APIS, **kwargs):

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import textwrap
-from StringIO import StringIO
+from six import StringIO
 
 from indicoio import config
 from indicoio.config import Settings

--- a/tests/test_imagerecognition.py
+++ b/tests/test_imagerecognition.py
@@ -15,7 +15,7 @@ class ImageRecognitionTest(unittest.TestCase):
         response = image_recognition(test_data, api_key = self.api_key, top_n=3)
         self.assertIsInstance(response, dict)
         self.assertEqual(len(response), 3)
-        self.assertIsInstance(response.values()[0], float)
+        self.assertIsInstance(list(response.values())[0], float)
 
     def test_batch_image_recognition(self):
         test_data = os.path.normpath(os.path.join(DIR, "data", "fear.png"))
@@ -23,7 +23,7 @@ class ImageRecognitionTest(unittest.TestCase):
         self.assertIsInstance(response, list)
         self.assertIsInstance(response[0], dict)
         self.assertEqual(len(response[0]), 3)
-        self.assertIsInstance(response[0].values()[0], float)
+        self.assertIsInstance(list(response[0].values())[0], float)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -6,6 +6,7 @@ from PIL import Image
 from requests import ConnectionError
 
 from nose.plugins.skip import Skip, SkipTest
+from six import PY3
 
 from indicoio import config
 from indicoio import political, sentiment, fer, facial_features, facial_localization, content_filtering, language, image_features, text_tags
@@ -189,6 +190,7 @@ class BatchAPIRun(unittest.TestCase):
                             analyze_text,
                             "this shouldn't work",
                             apis=["fer", "sentiment", "facial_features"])
+
     def test_batch_multi_bad_mixed_api(self):
         self.assertRaises(IndicoError,
                             analyze_text,
@@ -250,7 +252,8 @@ class FullAPIRun(unittest.TestCase):
 
         results = keywords(text, language = 'detect')
         sorted_results = sorted(results.keys(), key=lambda x:results.get(x), reverse=True)
-        self.assertTrue(set(map(lambda x: x.encode("utf-8"), results.keys())).issubset(words))
+        result_keys = results.keys() if PY3 else map(lambda x: x.encode("utf-8"), results.keys())
+        self.assertTrue(set(result_keys).issubset(words))
 
         results = keywords(text, top_n=3)
         assert len(results) is 3
@@ -266,7 +269,8 @@ class FullAPIRun(unittest.TestCase):
         results = keywords(text, language = 'French')
         sorted_results = sorted(results.keys(), key=lambda x:results.get(x), reverse=True)
 
-        self.assertTrue(set(map(lambda x: x.encode("utf-8"), results.keys())).issubset(words))
+        result_keys = results.keys() if PY3 else map(lambda x: x.encode("utf-8"), results.keys())
+        self.assertTrue(set(result_keys).issubset(words))
 
         results = keywords(text, top_n=3)
         assert len(results) is 3

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,6 +1,7 @@
 from indicoio.utils.image import image_preprocess
 from PIL import Image
-import os, unittest, base64, StringIO
+import os, unittest, base64
+from six import BytesIO
 
 DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -11,6 +12,6 @@ class ResizeTests(unittest.TestCase):
     def test_min_axis_resize(self):
         test_image = os.path.normpath(os.path.join(DIR, "data/fear.png"))
         resized_image = image_preprocess(test_image, min_axis=360)
-        image_string = StringIO.StringIO(base64.b64decode(resized_image))
+        image_string = BytesIO(base64.b64decode(resized_image))
         image = Image.open(image_string)
         self.assertEqual(image.size, (360.0, 360.0))


### PR DESCRIPTION
This is an attempted improvement over PR #117 which dropped python 2 compatiblity. Most tests (all except numpy tests) should pass on python 2.7 and 3.4.

Also removes some unused imports.